### PR TITLE
Accept

### DIFF
--- a/headers.tf
+++ b/headers.tf
@@ -27,7 +27,7 @@ locals {
   headers = {
     "Access-Control-Allow-Headers"     = "'${join(",", var.allow_headers)}'"
     "Access-Control-Allow-Methods"     = "'${join(",", var.allow_methods)}'"
-    "Access-Control-Allow-Origin"      = ""
+    "Access-Control-Allow-Origin"      =  contains(var.allow_origin, "*") ? "*" : ""
     "Access-Control-Max-Age"           = "'${var.allow_max_age}'"
     "Access-Control-Allow-Credentials" = var.allow_credentials ? "'true'" : ""
   }

--- a/headers.tf
+++ b/headers.tf
@@ -27,7 +27,7 @@ locals {
   headers = {
     "Access-Control-Allow-Headers"     = "'${join(",", var.allow_headers)}'"
     "Access-Control-Allow-Methods"     = "'${join(",", var.allow_methods)}'"
-    "Access-Control-Allow-Origin"      = "'${var.allow_origin}'"
+    "Access-Control-Allow-Origin"      = ""
     "Access-Control-Max-Age"           = "'${var.allow_max_age}'"
     "Access-Control-Allow-Credentials" = var.allow_credentials ? "'true'" : ""
   }

--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,19 @@ resource "aws_api_gateway_integration_response" "_" {
 
   response_parameters = local.integration_response_parameters
 
+  response_templates = {
+    "application/json" = <<E0F
+{
+    $input.json("$")
+    #set($domains = ["${join("\", \"", var.allow_origin)}"])
+    #set($origin = $input.params("origin"))
+    #if($domains.contains($origin))
+    #set($context.responseOverride.header.Access-Control-Allow-Origin="$origin")
+    #end
+}
+E0F
+  }
+
   depends_on = [
     aws_api_gateway_integration._,
     aws_api_gateway_method_response._,

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "aws_api_gateway_integration_response" "_" {
 
   response_parameters = local.integration_response_parameters
 
-  response_templates = {
+  response_templates = !contains(var.allow_origin, "*") ? {
     "application/json" = <<E0F
 {
     $input.json("$")
@@ -64,7 +64,7 @@ resource "aws_api_gateway_integration_response" "_" {
     #end
 }
 E0F
-  }
+  } : {}
 
   depends_on = [
     aws_api_gateway_integration._,

--- a/variables.tf
+++ b/variables.tf
@@ -69,8 +69,8 @@ variable "allow_methods" {
 # var.allow_origin
 variable "allow_origin" {
   description = "Allow origin"
-  type        = string
-  default     = "*"
+  type        = list(string)
+  default     = ["*"]
 }
 
 # var.allow_max_age


### PR DESCRIPTION
Made change so the allow_origin variable is now a list(string) instead of a string. Any origins passed into this list will be added to the response mapping template to support that origin, instead of putting it directly into the access-control-allow-origin header, which can only support one single origin or wildcard.